### PR TITLE
feat: 新增線上餐廳菜單分類建立功能及相關工具配置

### DIFF
--- a/.clinerules/ichef-mcp.md
+++ b/.clinerules/ichef-mcp.md
@@ -1,0 +1,32 @@
+You are an iCHEF SaaS platform backend configuration assistant specializing in helping customers complete backend configuration requirements.
+
+## Focus Areas
+- Complete backend menu item configuration using MCP tools
+- Transform customer requirements into iCHEF menu item formats
+- Remind users to apply configuration profiles on iCHEF POS after setup completion for changes to take effect
+
+## Approach
+1. By default, only provide information about currently enabled products, excluding disabled products from explanations. Do not specify which products are enabled unless specifically asked by the user.
+
+2. When users present requirements, first confirm what essential information is missing from their request (e.g., product pricing). You may suggest references or ask users to provide additional details - never make arbitrary decisions on their behalf.
+
+3. Before executing any action, you must confirm with the user exactly what you are about to do and get their approval before proceeding with the actual execution.
+
+4. For secondary technical data fields like UUIDs and other technical parameters, do not display these to users during task execution.
+
+5. When handling combo products, note that a combo product consists of multiple individual items. Ensure all individual items intended for the combo already exist - if not, they must be created first.
+
+6. Before deleting products, check the following conditions:
+   - Whether the product is listed on the online restaurant
+   - Whether the product is the only option in any combo sub-category
+   - If either condition is met, list all situations to the user and ask for deletion confirmation. If the user insists on deletion, handle accordingly:
+     - Remove the product from the online restaurant
+     - Ask the user whether to delete the sub-category or replace it with another product (combo sub-categories cannot be empty)
+
+7. After product created tasks, ask whether they want to synchronize the product to the Online Store, and handle according to their response. 
+
+8. After completing product-related tasks, remind users to apply the configuration profile on iCHEF POS to finalize the setup.
+
+9. Always respond in the user's preferred language based on their communication patterns.
+
+Focus on menu configuration completeness and content accuracy, especially when handling complex tasks like combo setup or product deletion.

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ build/
 schema.json
 src/types/generated.ts
 .DS_Store
+.cursorrules/
+.cursor/
+.vscode/
 ichef-setting-agent.dxt

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ src/types/generated.ts
 .cursor/
 .vscode/
 ichef-setting-agent.dxt
-README.md

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/types/generated.ts
 .cursor/
 .vscode/
 ichef-setting-agent.dxt
+README.md

--- a/src/api/gql/createOnlineRestaurantMenuCategoryMutation.ts
+++ b/src/api/gql/createOnlineRestaurantMenuCategoryMutation.ts
@@ -1,0 +1,21 @@
+import { gql } from 'graphql-request';
+
+export const ONLINE_RESTAURANT_MENU_CATEGORY_CREATE_MUTATION = gql`
+  mutation onlineRestaurantMenuItemCategoryCreateMutation(
+    $payload: CreateOnlineRestaurantMenuCategoryPayload!
+  ) {
+    restaurant {
+      settings {
+        menu {
+          integration {
+            onlineRestaurant {
+              createMenuCategory(payload: $payload) {
+                uuid
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/api/gql/onlineRestaurantMenuItemListingQuery.ts
+++ b/src/api/gql/onlineRestaurantMenuItemListingQuery.ts
@@ -15,6 +15,10 @@ export const ONLINE_RESTAURANT_MENU_ITEM_LISTING_QUERY = gql`
                 menuItems {
                   ...onlineRestaurantMenuItemItemListingFragment
                 }
+                menuHoursList {
+                  uuid
+                  name
+                }
                 __typename
               }
               __typename

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import winston from 'winston';
 import batchDeleteOnlineRestaurantMenuItems from './tools/batchDeleteOnlineRestaurantMenuItems.js';
 import createMenuItem from './tools/createMenuItem.js';
 import createMenuItemCategory from './tools/createMenuItemCategory.js';
+import createOnlineRestaurantMenuCategory from './tools/createOnlineRestaurantMenuCategory.js';
 import deleteMenuItem from './tools/deleteMenuItem.js';
 import getAllMenuItems from './tools/getAllMenuItems.js';
 import getMenuItemDetails from './tools/getMenuItemDetails.js';
@@ -58,6 +59,7 @@ const tools = [
   getAllMenuItems,
   createMenuItem,
   createMenuItemCategory,
+  createOnlineRestaurantMenuCategory,
   deleteMenuItem,
   updateMenuItem,
   updateSoldOutMenuItem,

--- a/src/tools/createOnlineRestaurantMenuCategory.ts
+++ b/src/tools/createOnlineRestaurantMenuCategory.ts
@@ -1,0 +1,97 @@
+import { ONLINE_RESTAURANT_MENU_CATEGORY_CREATE_MUTATION } from '../api/gql/createOnlineRestaurantMenuCategoryMutation.js';
+import { createGraphQLClient } from '../api/graphqlClient.js';
+import { IChefMcpTool, McpToolResponse } from '../types/mcpTypes.js';
+
+interface CreateOnlineRestaurantMenuCategoryArgs {
+  name: string;
+  menuHoursUuids: string[];
+  description?: string;
+}
+
+const createOnlineRestaurantMenuCategory: IChefMcpTool = {
+  name: 'createOnlineRestaurantMenuCategory',
+  description: '建立新的線上餐廳菜單類別',
+  category: 'menu',
+  version: '1.0.0',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        description: '線上餐廳菜單類別名稱',
+      },
+      menuHoursUuids: {
+        type: 'array',
+        items: { type: 'string' },
+        description: '菜單時段 UUID 陣列 (對應 menuHoursList 中的 uuid 欄位)',
+      },
+      description: {
+        type: 'string',
+        description: '線上餐廳菜單類別描述（選填）',
+      },
+    },
+    required: ['name', 'menuHoursUuids'],
+  },
+  handler: async (args?: Record<string, unknown>): Promise<McpToolResponse> => {
+    try {
+      const { name, menuHoursUuids, description } = (args as unknown) as CreateOnlineRestaurantMenuCategoryArgs;
+      
+      if (!name || typeof name !== 'string' || name.trim().length === 0) {
+        throw new Error('線上餐廳菜單類別名稱不能為空');
+      }
+
+      if (!menuHoursUuids || !Array.isArray(menuHoursUuids) || menuHoursUuids.length === 0) {
+        throw new Error('菜單時段 UUID 陣列不能為空');
+      }
+
+      // Validate that all menuHoursUuids are valid UUIDs
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+      const invalidUuids = menuHoursUuids.filter(uuid => typeof uuid !== 'string' || !uuidRegex.test(uuid));
+      if (invalidUuids.length > 0) {
+        throw new Error(`無效的 UUID 格式: ${invalidUuids.join(', ')}`);
+      }
+
+      const client = createGraphQLClient();
+      const payload = { 
+        name: name.trim(),
+        menuHoursUuids: menuHoursUuids,
+        ...(description && description.trim().length > 0 && { description: description.trim() })
+      };
+      
+      const data = await client.request(
+        ONLINE_RESTAURANT_MENU_CATEGORY_CREATE_MUTATION,
+        { payload }
+      ) as any;
+
+      const categoryUuid = data?.restaurant?.settings?.menu?.integration?.onlineRestaurant?.createMenuCategory?.uuid;
+      
+      if (!categoryUuid) {
+        throw new Error('建立線上餐廳菜單類別失敗，未收到有效的 UUID');
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `✅ 線上餐廳菜單類別「${name}」建立成功！\nUUID: ${categoryUuid}`,
+          },
+        ],
+      };
+    } catch (error) {
+      let errorMessage = 'Unknown error occurred';
+      if (error instanceof Error) errorMessage = error.message;
+      
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `🚨 建立線上餐廳菜單類別失敗: ${errorMessage}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+};
+
+export default createOnlineRestaurantMenuCategory;

--- a/src/tools/getOnlineRestaurantMenuItemListing.ts
+++ b/src/tools/getOnlineRestaurantMenuItemListing.ts
@@ -31,7 +31,13 @@ const formatOnlineRestaurantMenuData = (
     result += `## ${category.name} (分類 ${categoryIndex + 1})\n`;
     result += `- 分類 UUID: ${category.uuid}\n`;
     result += `- 排序索引: ${category.sortingIndex}\n`;
-    result += `- 菜單項目數量: ${category.menuItems.length}\n\n`;
+    result += `- 菜單項目數量: ${category.menuItems.length}\n`;
+    
+    // 顯示菜單時段資訊
+    if (category.menuHoursList && category.menuHoursList.length > 0) {
+      result += `- 菜單時段: ${category.menuHoursList.map(hours => `${hours.name} (${hours.uuid})`).join(', ')}\n`;
+    }
+    result += '\n';
 
     if (category.menuItems.length > 0) {
       // 按照 sortingIndex 排序菜單項目

--- a/src/types/menuTypes.ts
+++ b/src/types/menuTypes.ts
@@ -306,6 +306,13 @@ export interface AuthValidationResult {
   error?: string;
 }
 
+// 菜單時段類型
+export interface MenuHoursType {
+  uuid: UUID;
+  name: string;
+  __typename?: string;
+}
+
 // 外送菜單分類型別
 export interface OnlineRestaurantMenuCategory {
   _id: UUID;
@@ -313,6 +320,7 @@ export interface OnlineRestaurantMenuCategory {
   name: string;
   sortingIndex: number;
   menuItems: OnlineRestaurantMenuItem[];
+  menuHoursList?: MenuHoursType[];
   __typename?: string;
 }
 


### PR DESCRIPTION
- 新增 createOnlineRestaurantMenuCategory 工具，支援線上餐廳菜單分類建立
- 新增對應的 GraphQL mutation 及類型定義
- 更新菜單項目查詢以包含菜單時段資訊
- 新增 iCHEF MCP 工具配置規則文件
- 更新 .gitignore 以排除編輯器配置文件

🤖 Generated with [Claude Code](https://claude.ai/code)