### PR TITLE
refactor: 移除套餐選項的選擇規則相關屬性及驗證邏輯

### DIFF
--- a/src/tools/createMenuItem.ts
+++ b/src/tools/createMenuItem.ts
@@ -91,8 +91,6 @@ const formatCreateSuccessResponse = (
     result += '\n📋 套餐結構:\n';
     newItem.comboItemCategories.forEach((category, categoryIndex) => {
       result += `\n📂 分類 ${categoryIndex + 1}: ${category.name}\n`;
-      result += `   ├─ 選擇規則: 最少 ${category.minimumSelection || 1} 項，最多 ${category.maximumSelection || 1} 項\n`;
-      result += `   ├─ 可重複選擇: ${category.allowRepeatableSelection ? '是' : '否'}\n`;
       result += `   └─ 商品選項 (${category.comboMenuItems.length} 項):\n`;
 
       category.comboMenuItems.forEach((item, itemIndex) => {
@@ -231,23 +229,6 @@ const createMenuItem: IChefMcpTool = {
               minLength: 1,
               maxLength: 255,
             },
-            allowRepeatableSelection: {
-              type: 'boolean',
-              description: '是否允許重複選擇（選填，預設為 false）',
-              default: false,
-            },
-            minimumSelection: {
-              type: 'number',
-              description: '最少選擇數量（選填，預設為 1）',
-              minimum: 0,
-              default: 1,
-            },
-            maximumSelection: {
-              type: 'number',
-              description: '最多選擇數量（選填，預設為 1）',
-              minimum: 1,
-              default: 1,
-            },
             comboMenuItems: {
               type: 'array',
               description: '套餐選項（必填）',
@@ -346,33 +327,6 @@ const createMenuItem: IChefMcpTool = {
             );
           }
 
-          // 驗證選擇數量設定
-          const minSelection =
-            category.minimumSelection !== undefined
-              ? category.minimumSelection
-              : 1;
-          const maxSelection =
-            category.maximumSelection !== undefined
-              ? category.maximumSelection
-              : 1;
-
-          if (minSelection < 0) {
-            throw new Error(
-              `第 ${categoryIndex + 1} 個分類的最少選擇數量不能小於 0`
-            );
-          }
-
-          if (maxSelection < 1) {
-            throw new Error(
-              `第 ${categoryIndex + 1} 個分類的最多選擇數量不能小於 1`
-            );
-          }
-
-          if (maxSelection < minSelection) {
-            throw new Error(
-              `第 ${categoryIndex + 1} 個分類的最多選擇數量不能小於最少選擇數量`
-            );
-          }
 
           // 驗證套餐選項
           if (
@@ -547,10 +501,9 @@ const createMenuItem: IChefMcpTool = {
         payload.comboItemCategories = createArgs.comboItemCategories.map(
           category => ({
             name: category.name.trim(),
-            allowRepeatableSelection:
-              category.allowRepeatableSelection || false,
-            minimumSelection: category.minimumSelection || 1,
-            maximumSelection: category.maximumSelection || 1,
+            allowRepeatableSelection: false,
+            minimumSelection: 1,
+            maximumSelection: 1,
             comboMenuItemSortingType: 'DEFAULT',
             comboMenuItems: (category.comboMenuItems || []).map(item => ({
               menuItemUuid: item.menuItemUuid,

--- a/src/tools/deleteMenuItem.ts
+++ b/src/tools/deleteMenuItem.ts
@@ -61,8 +61,6 @@ const formatDeleteSuccessResponse = (
     result += '\n📋 已刪除的套餐結構:\n';
     deletedItem.comboItemCategories.forEach((category, categoryIndex) => {
       result += `\n📂 分類 ${categoryIndex + 1}: ${category.name}\n`;
-      result += `   ├─ 選擇規則: 最少 ${category.minimumSelection || 1} 項，最多 ${category.maximumSelection || 1} 項\n`;
-      result += `   ├─ 可重複選擇: ${category.allowRepeatableSelection ? '是' : '否'}\n`;
       result += `   └─ 商品選項 (${category.comboMenuItems.length} 項):\n`;
 
       category.comboMenuItems.forEach((item, itemIndex) => {

--- a/src/tools/getMenuItemDetails.ts
+++ b/src/tools/getMenuItemDetails.ts
@@ -160,9 +160,6 @@ const formatMenuItemDetails = (menuItem: MenuItemType): string => {
     menuItem.comboItemCategories.forEach((category, index) => {
       result += `   ${index + 1}. 分類名稱: ${category.name}\n`;
       result += `      - UUID: ${category.uuid}\n`;
-      result += `      - 允許重複選擇: ${category.allowRepeatableSelection ? '✅' : '❌'}\n`;
-      result += `      - 最少選擇數量: ${category.minimumSelection || '無限制'}\n`;
-      result += `      - 最多選擇數量: ${category.maximumSelection || '無限制'}\n`;
       result += `      - 排序方式: ${category.comboMenuItemSortingType}\n`;
 
       // 子品項資訊

--- a/src/tools/updateMenuItem.ts
+++ b/src/tools/updateMenuItem.ts
@@ -123,12 +123,6 @@ const formatUpdateSuccessResponse = (
       updatedFields.push(`   套餐子項目詳情:`);
       args.comboItemCategories.forEach((category, index) => {
         updatedFields.push(`     📂 子項目 ${index + 1}: ${category.name}`);
-        updatedFields.push(
-          `        ├─ 選擇規則: 最少 ${category.minimumSelection} 項，最多 ${category.maximumSelection} 項`
-        );
-        updatedFields.push(
-          `        ├─ 重複選擇: ${category.allowRepeatableSelection ? '允許' : '不允許'}`
-        );
 
         if (category.comboMenuItemSortingType) {
           updatedFields.push(
@@ -301,20 +295,6 @@ const updateMenuItem: IChefMcpTool = {
               minLength: 1,
               maxLength: 255,
             },
-            allowRepeatableSelection: {
-              type: 'boolean',
-              description: '是否允許重複選擇（必填）',
-            },
-            minimumSelection: {
-              type: 'number',
-              description: '最少選擇數量（必填）',
-              minimum: 0,
-            },
-            maximumSelection: {
-              type: 'number',
-              description: '最多選擇數量（必填）',
-              minimum: 0,
-            },
             comboMenuItemSortingType: {
               type: 'string',
               enum: ['MANUAL', 'ALPHABETICAL'],
@@ -350,9 +330,6 @@ const updateMenuItem: IChefMcpTool = {
           },
           required: [
             'name',
-            'allowRepeatableSelection',
-            'minimumSelection',
-            'maximumSelection',
           ],
         },
       },
@@ -559,37 +536,7 @@ const updateMenuItem: IChefMcpTool = {
             throw new Error(`第 ${i + 1} 個套餐子項目的 UUID 格式不正確`);
           }
 
-          // 驗證必填布林值
-          if (typeof category.allowRepeatableSelection !== 'boolean') {
-            throw new Error(
-              `第 ${i + 1} 個套餐子項目的 allowRepeatableSelection 必須是布林值`
-            );
-          }
 
-          // 驗證選擇數量
-          if (
-            typeof category.minimumSelection !== 'number' ||
-            category.minimumSelection < 0
-          ) {
-            throw new Error(
-              `第 ${i + 1} 個套餐子項目的 minimumSelection 必須是非負整數`
-            );
-          }
-
-          if (
-            typeof category.maximumSelection !== 'number' ||
-            category.maximumSelection < 0
-          ) {
-            throw new Error(
-              `第 ${i + 1} 個套餐子項目的 maximumSelection 必須是非負整數`
-            );
-          }
-
-          if (category.minimumSelection > category.maximumSelection) {
-            throw new Error(
-              `第 ${i + 1} 個套餐子項目的 minimumSelection 不能大於 maximumSelection`
-            );
-          }
 
           // 驗證排序類型（選填）
           if (
@@ -705,7 +652,12 @@ const updateMenuItem: IChefMcpTool = {
       }
 
       if (updateArgs.comboItemCategories !== undefined) {
-        payload.comboItemCategories = updateArgs.comboItemCategories;
+        payload.comboItemCategories = updateArgs.comboItemCategories.map(category => ({
+          ...category,
+          allowRepeatableSelection: false,
+          minimumSelection: 1,
+          maximumSelection: 1,
+        }));
       }
 
       // 建立 GraphQL 客戶端
@@ -804,12 +756,6 @@ const updateMenuItem: IChefMcpTool = {
       ) {
         errorMessage =
           '❌ 套餐商品相關錯誤，請檢查商品類型是否為套餐或套餐子項目結構是否正確';
-      } else if (
-        errorMessage.includes('minimumSelection') ||
-        errorMessage.includes('maximumSelection')
-      ) {
-        errorMessage =
-          '❌ 套餐子項目選擇規則錯誤，請確保最少選擇數量不超過最多選擇數量';
       }
 
       return {


### PR DESCRIPTION
- 刪除 createMenuItem、deleteMenuItem、getMenuItemDetails 和 updateMenuItem 中與最少/最多選擇數量及重複選擇相關的屬性和驗證邏輯
- 更新回應格式，移除不必要的選擇規則顯示
- 確保套餐選項的默認值為最少選擇 1 項，最多選擇 1 項，並不允許重複選擇